### PR TITLE
Fix an OOB when the BreakSpeed event is cancelled

### DIFF
--- a/CoFHCore/src/main/java/cofh/core/event/AreaEffectClientEvents.java
+++ b/CoFHCore/src/main/java/cofh/core/event/AreaEffectClientEvents.java
@@ -129,7 +129,7 @@ public class AreaEffectClientEvents {
         if (progress < 0) {
             return;
         }
-        progress = Math.min(progress, 9); // Ensure that for whatever reason the progress level doesn't go OOB.
+        progress = Math.min(progress, 8); // Ensure that for whatever reason the progress level doesn't go OOB.
 
         BlockRendererDispatcher dispatcher = Minecraft.getInstance().getBlockRendererDispatcher();
         IVertexBuilder vertexBuilder = worldRender.renderTypeTextures.getCrumblingBufferSource().getBuffer(ModelBakery.DESTROY_RENDER_TYPES.get(progress + 1));


### PR DESCRIPTION
So basically when using the `PlayerEvent.BreakSpeed`, if you cancel it, and then try and hit a 1 hit break block (like tall grass), `Minecraft.getInstance().playerController.curBlockDamageMP ` somehow returns "infinity", setting the progress to the max integer value.

The thing is, `ModelBakery.DESTROY_RENDER_TYPES` has 10 entries (0 -> 9), so when you do `progress + 1` with the max of 9 progress, you get an index of 10 and get the OOB.

In my testing without the break speed event, with a bunch of tools / empty hand with the haste / mining fatigue effect, I can't find a way to get a progress to be `9`, it gets close, but it never rolls over to `9`, always stays at max `8`, so the max was always `8` anyway