### PR TITLE
Check for property instead of block type

### DIFF
--- a/ThermalCore/src/main/java/cofh/thermal/core/tileentity/device/DeviceHiveExtractorTile.java
+++ b/ThermalCore/src/main/java/cofh/thermal/core/tileentity/device/DeviceHiveExtractorTile.java
@@ -79,7 +79,7 @@ public class DeviceHiveExtractorTile extends ThermalTileBase {
     protected void updateActiveState() {
 
         boolean curActive = isActive;
-        isActive = redstoneControl().getState() && world.getBlockState(pos.up()).getBlock() instanceof BeehiveBlock;
+        isActive = redstoneControl().getState() && world.getBlockState(pos.up()).hasProperty(BeehiveBlock.HONEY_LEVEL);
         updateActiveState(curActive);
     }
 


### PR DESCRIPTION
Not all modded beehives extend the vanilla BeehiveBlock so it's better to check if the blockstate property exists