### PR TITLE
Corrected Fluorite Ore Name in Compat Recipe

### DIFF
--- a/ThermalExpansion/src/main/resources/data/thermal/recipes/compat/mekanism/pulverizer_mekanism_fluorite_ore.json
+++ b/ThermalExpansion/src/main/resources/data/thermal/recipes/compat/mekanism/pulverizer_mekanism_fluorite_ore.json
@@ -1,7 +1,7 @@
 {
   "type": "thermal:pulverizer",
   "ingredient": {
-    "tag": "forge:ores/fluorite_gem"
+    "tag": "forge:ores/fluorite"
   },
   "result": [
     {


### PR DESCRIPTION
This fixes an invalid pulverizer recipe:
![billede](https://user-images.githubusercontent.com/21295394/113346582-534bef80-9334-11eb-9e76-48ef58b35af0.png)
