### PR TITLE
Fixed weird forge bug with DistExecutor crashing on servers in dev

### DIFF
--- a/CoFHCore/src/main/java/cofh/core/CoFHCore.java
+++ b/CoFHCore/src/main/java/cofh/core/CoFHCore.java
@@ -48,7 +48,7 @@ public class CoFHCore {
 
     public static final Logger LOG = LogManager.getLogger(ID_COFH_CORE);
     public static final PacketHandler PACKET_HANDLER = new PacketHandler(new ResourceLocation(ID_COFH_CORE, "general"));
-    public static final Proxy PROXY = DistExecutor.safeRunForDist(() -> ProxyClient::new, () -> Proxy::new);
+    public static final Proxy PROXY = DistExecutor.unsafeRunForDist(() -> ProxyClient::new, () -> Proxy::new);
 
     public static final DeferredRegisterCoFH<Block> BLOCKS = DeferredRegisterCoFH.create(ForgeRegistries.BLOCKS, ID_COFH_CORE);
     public static final DeferredRegisterCoFH<Fluid> FLUIDS = DeferredRegisterCoFH.create(ForgeRegistries.FLUIDS, ID_COFH_CORE);


### PR DESCRIPTION
No clue why this happens but I uploaded to a test maven server and it doesn't crash in dev anymore.