### PR TITLE
fixed smelter slimesteel recipe for tinkers compat

### DIFF
--- a/ThermalExpansion/src/main/resources/data/thermal/recipes/compat/tconstruct/smelter_alloy_tconstruct_slimesteel_ingot.json
+++ b/ThermalExpansion/src/main/resources/data/thermal/recipes/compat/tconstruct/smelter_alloy_tconstruct_slimesteel_ingot.json
@@ -6,7 +6,7 @@
       "count": 1
     },
     {
-      "item": "tconstruct:blue_slime_ball",
+      "item": "tconstruct:sky_slime_ball",
       "count": 1
     },
     {


### PR DESCRIPTION
Tinkers Construct changed the name of the slime ball in 1.16.
In order to prevent recipe parsing errors, this needs adjustment.

I am also still getting parsing errors for `pig_iron` which is already fixed in your code:
https://github.com/KingLemming/1.16/blob/main/ThermalExpansion/src/main/resources/data/thermal/recipes/compat/tconstruct/chiller_tconstruct_pigiron_ingot.json
https://github.com/KingLemming/1.16/blob/main/ThermalExpansion/src/main/resources/data/thermal/recipes/compat/tconstruct/smelter_alloy_tconstruct_pigiron_ingot.json
When is this code released in an update? The current version still uses `pigiron`.

There are also a ton of parsing errors in the current version of the Mystical Agriculture compat because you are adding stuff which is not covered by MA:
https://pastebin.com/wc5TwKW1